### PR TITLE
Some suggestions

### DIFF
--- a/src/1D/spline_cache_1D.jl
+++ b/src/1D/spline_cache_1D.jl
@@ -60,25 +60,25 @@ A reference for the calculations in this script can be found in Chapter 1 of
    [hal-03017566v2](https://hal.archives-ouvertes.fr/hal-03017566v2)
 """
 function LinearBSpline(x::Vector, y::Vector)
-  if length(x) == length(y)
-    if length(x) == 1
-      @error("To perform linear B-spline interpolation, we need an x vector which 
-              contains at least 2 values.")
-    else
-      x,y = sort_data(x,y)
-
-      h = x[2] - x[1]
-
-      IP = [-1 1;
-             1 0]
-
-      Q = y
-
-      LinearBSpline(x, h, Q, IP)
-    end
-  else
+  if length(x) != length(y)
     @error("Vectors x and y have to contain the same number of values")
   end
+
+  if length(x) == 1
+    @error("To perform linear B-spline interpolation, we need an x vector which 
+            contains at least 2 values.")
+  end
+
+  x,y = sort_data(x,y)
+
+  h = x[2] - x[1]
+
+  IP = [-1 1;
+        1 0]
+
+  Q = y
+
+  LinearBSpline(x, h, Q, IP)
 end
 
 # Read from file

--- a/src/1D/spline_cache_1D.jl
+++ b/src/1D/spline_cache_1D.jl
@@ -59,8 +59,7 @@ A reference for the calculations in this script can be found in Chapter 1 of
    Cubic and bicubic spline interpolation in Python. 
    [hal-03017566v2](https://hal.archives-ouvertes.fr/hal-03017566v2)
 """
-function linear_b_spline(x::Vector, y::Vector)
-
+function LinearBSpline(x::Vector, y::Vector)
   if length(x) == length(y)
     if length(x) == 1
       @error("To perform linear B-spline interpolation, we need an x vector which 
@@ -80,7 +79,6 @@ function linear_b_spline(x::Vector, y::Vector)
   else
     @error("Vectors x and y have to contain the same number of values")
   end
-
 end
 
 # Read from file

--- a/src/1D/spline_cache_1D.jl
+++ b/src/1D/spline_cache_1D.jl
@@ -18,14 +18,10 @@ These attributes are:
 - `IP`: Coefficients matrix
 """
 mutable struct LinearBSpline{x_type, h_type, Q_type, IP_type}
-
   x::x_type
   h::h_type
   Q::Q_type
   IP::IP_type
-
-  LinearBSpline(x, h, Q, IP) = new{typeof(x), typeof(h), typeof(Q), 
-  typeof(IP)}(x, h, Q, IP)
 end
 
 # Fill structure


### PR DESCRIPTION
1. Remove "trivial" inner constructors that are automatically created by Julia (57a4b730bc136d008007a0515ac6a2e9993bcb4b)
2. Rename functions such as `linear_b_spline` to `LinearBSpline` to make them proper outer constructor (c8de0153c297641e8d1d6d77eb80b0498f0bc768)
3. Reduce indentations by moving sanity checks to the beginning of a function (c563b88d643e62df73226e7c18490cf4afb5cb2e)

Please note that it in all cases I modified only a single instance. In each case, the changes should - if you think they are useful - be applied consistently to all types/functions. Also, you need to check the docstrings and update them if necessary.